### PR TITLE
fix: 'disposable' 안 되는 문제 수정

### DIFF
--- a/Nagaza/Sources/Presentation/Feature/Main/View/MainViewController.swift
+++ b/Nagaza/Sources/Presentation/Feature/Main/View/MainViewController.swift
@@ -13,6 +13,7 @@ final class MainViewController: UIViewController, Alertable {
     
     private let textField = UITextField()
     private let label = UILabel()
+    private let button = UIButton()
     
     private let disposeBag = DisposeBag()
     
@@ -38,6 +39,16 @@ final class MainViewController: UIViewController, Alertable {
             stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
             stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20)
         ])
+        
+        view.addSubview(button)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            button.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+            button.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: -16)
+        ])
+        button.setTitle("테스트", for: .normal)
+        button.setTitleColor(.black, for: .normal)
+        button.addTarget(self, action: #selector(cancelSubscribe), for: .touchUpInside)
     }
     
     // MARK: Input
@@ -45,9 +56,13 @@ final class MainViewController: UIViewController, Alertable {
         viewModel.textDidChange(text: textField.text)
     }
     
+    @objc private func cancelSubscribe() {
+        disposeBag.cancelSubscribe()
+    }
+    
     // MARK: Output
     private func bindViewModel() {
-        viewModel.textFieldText.subscribe(on: self)
+        viewModel.textFieldText.subscribe(on: self, disposeBag: disposeBag)
             .onNext { [weak self] text in
                 if let number = Int(text ?? "") {
                      let squared = number * number
@@ -60,9 +75,9 @@ final class MainViewController: UIViewController, Alertable {
                      }
                  } else {
                      self?.label.text = "숫자를 입력하세요"
-                 }            }
-            .disposedBy(disposeBag)
-        
+                 }
+                
+            }
     }
 }
 

--- a/Nagaza/Sources/Presentation/Utils/Disposable.swift
+++ b/Nagaza/Sources/Presentation/Utils/Disposable.swift
@@ -27,6 +27,11 @@ final class DisposeBag {
         disposables.add(disposable)
     }
     
+    // 테스트 용 
+    func cancelSubscribe() {
+        disposables.dispose()
+    }
+    
     deinit {
         disposables.dispose()
     }


### PR DESCRIPTION
## Motivation ⍰

-  Observable 구독 후 메모리 해제 안 되는 문제 해결 
- Main VIew Controller "테스트" 버튼을 통해 disposable 작동 상태 확인 가능 

<br>

## Key Changes 🔑

- 기존 disposable을 체이닝 할 수 있게 설정 했지만 체이닝 하면서 기존에 저장한 disposable 객체를 덮어쓰면서 기존 disposableBag 메모리 삭제됨 
- 그러므로 내부 클로저 객체가 없어져서 observable class와 연동 되도록 연결한 클로저 함수가 사라지는 현상 발견 
- 체이닝 기능 삭제 -> 최초 파라미터로 disposableBag을 넣어서 해당 disposableBag에 자동으로 생성된 disposable을 넣어주는 방식으로 변경
- 기존 체이닝 함수 삭제하고 subscribe를 하는 시점에 생성된 disposable를 파라미터로 넣어주면 됩니다.

<br>

## To Reviewers 🙏🏻

- 

<br>

## Linked Issue 🔗

- 
