### PR TITLE
Refector: Coordinator Protocol 변경

### DIFF
--- a/Nagaza/Sources/Application/AppFlowCoordinator.swift
+++ b/Nagaza/Sources/Application/AppFlowCoordinator.swift
@@ -50,16 +50,24 @@ extension AppFlowCoordinator {
         )
         
         let mainSceneDIContaier = appDIContainer.makeMainSceneDIContainer()
-        let mainFlow = mainSceneDIContaier.makeMainFlowCoordinator(navigationController: UINavigationController())
+        let mainFlow = mainSceneDIContaier.makeMainFlowCoordinator(
+            navigationController: UINavigationController()
+        )
         
         let mapSceneDIContaier = appDIContainer.makeMapSceneDIContainer()
-        let mapFlow = mapSceneDIContaier.makeMapFlowCoordinator(navigationController: UINavigationController())
+        let mapFlow = mapSceneDIContaier.makeMapFlowCoordinator(
+            navigationController: UINavigationController()
+        )
         
         let reviewSceneDIContaier = appDIContainer.makeReviewSceneDIContainer()
-        let reviewFlow = reviewSceneDIContaier.makeReviewFlowCoordinator(navigationController: UINavigationController())
+        let reviewFlow = reviewSceneDIContaier.makeReviewFlowCoordinator(
+            navigationController: UINavigationController()
+        )
         
         let myPageSceneDIContaier = appDIContainer.makeMyPageSceneDIContainer()
-        let myPageFlow = myPageSceneDIContaier.makeMyPageFlowCoordinator(navigationController: UINavigationController())
+        let myPageFlow = myPageSceneDIContaier.makeMyPageFlowCoordinator(
+            navigationController: UINavigationController()
+        )
       
         tabBarFlowCoordinator.setupTabs(with: [
             mainFlow,
@@ -76,12 +84,14 @@ extension AppFlowCoordinator {
     
     func showLogin() {
         let loginSceneDIContainer = appDIContainer.makeLoginSceneDIContainer()
-        let flow = loginSceneDIContainer.makeLoginFlowCoordinator(navigationController: navigationController)
+        let loginFlow = loginSceneDIContainer.makeLoginFlowCoordinator(
+            navigationController: navigationController
+        )
         
-        flow.finishDelegate = self
-        flow.start()
+        loginFlow.finishDelegate = self
+        loginFlow.start()
         
-        childCoordinators.append(flow)
+        childCoordinators.append(loginFlow)
     }
 }
 

--- a/Nagaza/Sources/Presentation/Feature/Flow/MainFlowCoordinator.swift
+++ b/Nagaza/Sources/Presentation/Feature/Flow/MainFlowCoordinator.swift
@@ -40,12 +40,16 @@ final class MainFlowCoordinator: Coordinator {
     }
     
     func start() {
-        let actions = MainViewModelActions(logoutTest: { [weak self] in self?.finish() })
+        let actions = MainViewModelActions(logoutTest: logoutTest)
         let vc = dependencies.makeMainViewController(actions: actions)
         
         navigationController.setNavigationBarHidden(true, animated: false)
         navigationController.pushViewController(vc, animated: false)
         
         mainVC = vc
+    }
+    
+    private func logoutTest() {
+        self.finish()
     }
 }

--- a/Nagaza/Sources/Presentation/Feature/Flow/TabBarFlowCoordinator.swift
+++ b/Nagaza/Sources/Presentation/Feature/Flow/TabBarFlowCoordinator.swift
@@ -17,7 +17,7 @@ final class TabBarFlowCoordinator: Coordinator {
     weak var finishDelegate: CoordinatorFinishDelegate?
     weak var tabBarDelegate: TabBarDelegate? = nil
     
-    private var tabBarController: NagazaTabBarController
+    private weak var tabBarVC: NagazaTabBarController!
     
     init(
         navigationController: UINavigationController,
@@ -25,7 +25,7 @@ final class TabBarFlowCoordinator: Coordinator {
     ) {
         print("TabBar Flow Init")
         self.navigationController = navigationController
-        self.tabBarController = tabBarController
+        self.tabBarVC = tabBarController
     }
     
     deinit {
@@ -33,12 +33,13 @@ final class TabBarFlowCoordinator: Coordinator {
     }
     
     func start() {
-        tabBarController.selectedIndex = 0
+        tabBarVC.selectedIndex = 0
+        
+        navigationController.pushViewController(tabBarVC, animated: false)
+        navigationController.setNavigationBarHidden(true, animated: false)
     }
     
     func setupTabs(with coordinators: [Coordinator]) {
-        navigationController.pushViewController(tabBarController, animated: false)
-        navigationController.setNavigationBarHidden(true, animated: false)
         
         var tabs: [TabBarType] = []
         
@@ -57,7 +58,7 @@ final class TabBarFlowCoordinator: Coordinator {
             }
             
             coordinator.finishDelegate = self
-            coordinator.tabBarDelegate = tabBarController
+            coordinator.tabBarDelegate = tabBarVC
             
             coordinator.start()
 
@@ -66,20 +67,13 @@ final class TabBarFlowCoordinator: Coordinator {
         
         let viewControllers = coordinators.map { $0.navigationController }
 
-        tabBarController.setViewControllers(viewControllers, with: tabs)
+        tabBarVC.setViewControllers(viewControllers, with: tabs)
     }
 }
 
 // MARK: Logout 버튼 클릭 시 tabBar Flow Coordinator도 같이 삭제
 extension TabBarFlowCoordinator: CoordinatorFinishDelegate {
     func coordinatorDidFinish(childCoordinator: Coordinator) {
-        childCoordinators = childCoordinators.filter({ $0.type != childCoordinator.type })
-
-        switch childCoordinator.type {
-        case .home:
-            self.finish()
-        default:
-            break
-        }
+        self.finish()
     }
 }

--- a/Nagaza/Sources/Presentation/Feature/Flow/TabBarFlowCoordinator.swift
+++ b/Nagaza/Sources/Presentation/Feature/Flow/TabBarFlowCoordinator.swift
@@ -17,7 +17,7 @@ final class TabBarFlowCoordinator: Coordinator {
     weak var finishDelegate: CoordinatorFinishDelegate?
     weak var tabBarDelegate: TabBarDelegate? = nil
     
-    private weak var tabBarVC: NagazaTabBarController!
+    private var tabBarVC: NagazaTabBarController!
     
     init(
         navigationController: UINavigationController,

--- a/Nagaza/Sources/Presentation/Feature/TabBar/MyPage/ViewModel/MyPageViewModel.swift
+++ b/Nagaza/Sources/Presentation/Feature/TabBar/MyPage/ViewModel/MyPageViewModel.swift
@@ -23,6 +23,7 @@ protocol MyPageViewModelOutput {
 typealias MyPageViewModelProtocol = MyPageViewModelInput & MyPageViewModelOutput
 
 final class MyPageViewModel: MyPageViewModelProtocol {
+    
     private let actions: MyPageViewModelActions!
     
     // MARK: Output

--- a/Nagaza/Sources/Presentation/Feature/TabBar/Review/ViewModel/ReviewViewModel.swift
+++ b/Nagaza/Sources/Presentation/Feature/TabBar/Review/ViewModel/ReviewViewModel.swift
@@ -23,6 +23,7 @@ protocol ReviewViewModelOutput {
 typealias ReviewViewModelProtocol = ReviewViewModelInput & ReviewViewModelOutput
 
 final class ReviewViewModel: ReviewViewModelProtocol {
+    
     private let actions: ReviewViewModelActions!
     
     // MARK: Output

--- a/Nagaza/Sources/Presentation/Utils/Common/Coordinator.swift
+++ b/Nagaza/Sources/Presentation/Utils/Common/Coordinator.swift
@@ -22,6 +22,13 @@ protocol Coordinator: AnyObject {
 
 extension Coordinator {
     func finish() {
+        
+        if !childCoordinators.isEmpty {
+            childCoordinators.forEach { $0.navigationController.viewControllers.removeAll() }
+        }
+        
+        navigationController.viewControllers.removeAll()
+        
         childCoordinators.removeAll()
         finishDelegate?.coordinatorDidFinish(childCoordinator: self)
     }

--- a/Nagaza/Sources/Presentation/Utils/Common/Coordinator.swift
+++ b/Nagaza/Sources/Presentation/Utils/Common/Coordinator.swift
@@ -21,10 +21,9 @@ protocol Coordinator: AnyObject {
 }
 
 extension Coordinator {
+    
     func finish() {
-        
-        if !childCoordinators.isEmpty {
-            childCoordinators.forEach { $0.navigationController.viewControllers.removeAll() }
+        childCoordinators.forEach { $0.navigationController.viewControllers.removeAll()
         }
         
         navigationController.viewControllers.removeAll()


### PR DESCRIPTION
## Motivation ⍰

- 기존 순환참조 되는 문제를 찾고보니 main을 갖고있는 NavigationController의 ViewController remove를 하지 않았기 때문임. 
- TabBar, Login이랑은 다른 NavigationContrller 
- 그러므로 각 NavigationController를 직접 Remove할 수 있도록 extension으로 옮김 
- extension에서는 
- 만약 childCoordinator가 존재하면 해당 coordinator에서 navigaionController.ViewController.removeAll()를 수행 후 coordinator를 제거 

<br>

## Key Changes 🔑

-  coordinator extension 변경 
- tabbarCoordinator에서 TabBarViewContrller weak var 처리 

<br>

## To Reviewers 🙏🏻

- 

<br>

## Linked Issue 🔗

- 
